### PR TITLE
Update sync-repo.sh

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -1,24 +1,17 @@
 # This bash script uses git to sync changes between a local and remote GitHub repository on branch 'main'.
 
-# Steps: 
-# - print message 'Synced changes with remote repository'
-# - pull changes from remote repository
-# - stage all changes
-# - commit changes with message 'Updated'
-# - push changes to remote repository on branch 'main'.
-
 # Print message 'Synced changes with remote repository'
 echo "Synced changes with remote repository"
 
 # Pull changes from remote repository
-git pull origin main
+git pull 
 
 # Stage all changes
-git stage .
+git add .
 
 # Commit changes with message 'Updated'
 git commit -m "Updated"
 
 # Push changes to remote repository on branch 'main'
-git push origin main
+git push 
 


### PR DESCRIPTION
This pull request includes a small change to the `sync-repo.sh` script to simplify the synchronization process between a local and remote GitHub repository. The most important changes are the removal of the branch specification for `git pull` and `git push` commands, and the correction of the staging command.

Simplification of synchronization process:

* [`sync-repo.sh`](diffhunk://#diff-575d6743e8681b18ec441739763eeedfba8676be8c62e5756a5d94ce5cf81de4L3-R16): Removed the branch specification from `git pull` and `git push` commands to use the default branch.
* [`sync-repo.sh`](diffhunk://#diff-575d6743e8681b18ec441739763eeedfba8676be8c62e5756a5d94ce5cf81de4L3-R16): Corrected `git stage .` to `git add .` for staging all changes.